### PR TITLE
Update template output to single not static to match docs

### DIFF
--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -24,7 +24,7 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
+      "output": "single",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": ["expo-router"],


### PR DESCRIPTION
Fix output file for web

# Why

In the docs Expo said the default is single page. So by using this template I was getting issue where window was not defined. And figured out the output was the issue cause of this static. This pr is more for fixing it to be like the docs said here 
<img width="849" alt="image" src="https://github.com/EQuimper/expo/assets/15819498/39570b3d-0478-45b1-a844-327398fc73da">

I think the user should be the one choosing the output if anything else than single.

# How

Change the web output to match the single page application default one from the docs https://docs.expo.dev/workflow/web/#alternative-rendering-patterns

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
